### PR TITLE
use pre-wrap instead of pre for addInLineBreaks

### DIFF
--- a/xbbcode.js
+++ b/xbbcode.js
@@ -771,7 +771,7 @@ var XBBCODE = (function() {
             ret.html = ret.html.replace(/\[.*?\]/g,"");
         }
         if (config.addInLineBreaks) {
-            ret.html = '<div style="white-space:pre;">' + ret.html + '</div>';
+            ret.html = '<div style="white-space:pre-wrap;">' + ret.html + '</div>';
         }
 
         ret.html = ret.html.replace("&#91;", "["); // put ['s back in


### PR DESCRIPTION
I've set white-space to "pre-wrap" instead of "pre" when addInLineBreaks mode is true.

"pre" causes long sequences of text to overflow the container even though they contain whitespace, whereas "pre-wrap" allows text to fit the container by adding line breaks when necessary.

https://developer.mozilla.org/en-US/docs/Web/CSS/white-space