### PR TITLE
Added `config.escapeHtml`

### DIFF
--- a/xbbcode.js
+++ b/xbbcode.js
@@ -774,9 +774,11 @@ var XBBCODE = (function() {
             ret.html = '<div style="white-space:pre-wrap;">' + ret.html + '</div>';
         }
 
-        ret.html = ret.html.replace("&#91;", "["); // put ['s back in
-        ret.html = ret.html.replace("&#93;", "]"); // put ['s back in
-
+		if (!config.escapeHtml) {
+			ret.html = ret.html.replace("&#91;", "["); // put ['s back in
+        	ret.html = ret.html.replace("&#93;", "]"); // put ['s back in
+		}
+		
         ret.error = errQueue.length !== 0;
         ret.errorQueue = errQueue;
 


### PR DESCRIPTION
This patch makes it possible to use:

``` js
var ret = parser.process({
  "escapeHtml": true,
  "text": "I have some <iframe src='http://google.de'></iframe> for [b]you[/b]"
})
// ret.html: "I have some &lt;iframe src='http://google.de'&gt;&lt;/iframe&gt; for <b>you</b>"
``` 

or

``` js
var ret = parser.process({
  "escapeHtml": false,
  "text": "I have some <iframe src='http://google.de'></iframe> for [b]you[/b]"
})
// ret.html: "I have some <iframe src='http://google.de'></iframe> for <b>you</b>"
``` 

where `escapeHtml` is by default `false` to stay backwards compatible.