### PR TITLE
[fix] Correctly transform HTML tags again

### DIFF
--- a/xbbcode.js
+++ b/xbbcode.js
@@ -758,6 +758,7 @@ var XBBCODE = (function() {
         var ret = {html: "", error: false},
             errQueue = [];
 
+        config.text = securityFixes(config.text);
         config.text = config.text.replace(/</g, "&lt;"); // escape HTML tag brackets
         config.text = config.text.replace(/>/g, "&gt;"); // escape HTML tag brackets
 
@@ -768,7 +769,6 @@ var XBBCODE = (function() {
             return "<" + contents + ">";
         });
 
-        config.text = securityFixes(config.text);
         config.text = config.text.replace(/\[/g, "&#91;"); // escape ['s that aren't apart of tags
         config.text = config.text.replace(/\]/g, "&#93;"); // escape ['s that aren't apart of tags
         config.text = config.text.replace(/</g, "["); // escape ['s that aren't apart of tags


### PR DESCRIPTION
`xbbcode-parse@0.2.1` seems to have introduced a bug converting HTML tags.

Taking `<h1>Hello World!</h1>` as input, it produces  `&lt&#59;h1&gt&#59;Hello World!&lt&#59;/h1&gt&#59;`.

I had expected `&lt;h1&gt;Hello World!&lt;/h1&gt;`

This commit fixes this.

Reproduction:

```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <link rel="stylesheet" type="text/css" href="xbbcode.css">
    <title>Example</title>
</head>
<body>
<script src="xbbcode.js"></script>
<script>
    var result = XBBCODE.process({
        text: "<h1>Hello World!</h1>",
    });
    console.error("Errors", result.error);
    console.dir(result.errorQueue);
    console.log(result.html);
</script>
</body>
</html>
```