### PR TITLE
fix: prevent duplicate HTML escaping in `securityFixes` function

### DIFF
--- a/xbbcode.js
+++ b/xbbcode.js
@@ -739,9 +739,9 @@ var XBBCODE = (function() {
 
     function securityFixes(text) {
         return text
+            .replaceAll(';', '&#59;')
             .replaceAll("'", '&#39;')
-            .replaceAll('"', '&quot;')
-            .replaceAll(';', '&#59;');
+            .replaceAll('"', '&quot;');
     }
 
     function addBbcodeLevels(text) {


### PR DESCRIPTION
Resolved an issue mentioned in #32 where incorrect code order in the securityFixes function caused ";" to be escaped multiple times.

bbcode: `"text"`
parsed html: `&quot&#59;text&quot&#59;`
expected html:`&quot;text&quot;`

Reproduction:
``` html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <link rel="stylesheet" type="text/css" href="xbbcode.css">
    <title>Example</title>
</head>
<body>
<script src="xbbcode.js"></script>
<script>
    var result = XBBCODE.process({
        text: `"double"`,
    });
    console.error("Errors", result.error);
    console.dir(result.errorQueue);
    console.log(result.html);
</script>
</body>
</html>
```